### PR TITLE
Create a filelist for each finished arch

### DIFF
--- a/build-complete.sh
+++ b/build-complete.sh
@@ -25,7 +25,9 @@ fi
 
 # Sanity prevails, do the copy
 for arch in ${ARCH_LIST}; do
-   sudo touch /var/www/images/kernel-ci/$TREE_NAME/$GIT_DESCRIBE/$arch.done
+    BASEDIR=/var/www/images/kernel-ci/$TREE_NAME/$GIT_DESCRIBE
+    sudo touch ${BASEDIR}/$arch.done
+    sudo find ${BASEDIR} -type f -name "*/$arch-*" > ${BASEDIR}/$arch.filelist
 done
 
 # Check if all builds for all architectures have finished. The magic number here is 3 (arm, arm64, x86)


### PR DESCRIPTION
This allows the LAVA job creator to read this
file rather than walking through subdirectories
over HTTP.
