### PR TITLE
build.py: strip kernel modules

### DIFF
--- a/build.py
+++ b/build.py
@@ -336,6 +336,8 @@ if install:
     if modules:
         tmp_mod_dir = tempfile.mkdtemp()
         os.environ['INSTALL_MOD_PATH'] = tmp_mod_dir
+        os.environ['INSTALL_MOD_STRIP'] = "1"
+        os.environ['STRIP'] = "%sstrip" %cross_compile
         do_make('modules_install')
         modules_tarball = "modules.tar.xz"
         cmd = "(cd %s; tar -Jcf %s lib/modules)" %(tmp_mod_dir, modules_tarball)


### PR DESCRIPTION
A number of defconfigs, including the arm64 defconfig, build
everything with debugging symbols enabled. While the kernel image
itself is stripped from its debugging symbols, it's not the case for
kernel modules. Due to this, the initramfs used for boot tests has
recently grown to 54 MB gzip-compressed on arm64. This is due to
having ~180 MB of kernel modules, which can very easily be reduced to
6.6 MB by stripping the kernel modules. The reason for this recent
growth is that some DRM GPU kernel modules have been added in the
defconfig: the nouveau.ko module is 99 MB with debugging symbols,
about 2.2 MB after stripping the debugging symbols.

In order to address this, we pass INSTALL_MOD_STRIP=1 at
modules_install time, and also pass the STRIP environment variable so
that it uses the proper strip utility.

Signed-off-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
