### PR TITLE
add kselftest-enabled kernel build (v2)

### DIFF
--- a/jenkins/kernel-defconfig-creator.sh
+++ b/jenkins/kernel-defconfig-creator.sh
@@ -77,6 +77,12 @@ if [ ${ARCH} = "x86" ]; then
   done
 fi
 
+# kselftests
+KSELFTEST_FRAG=kernel/configs/kselftest.config
+if [ -e $KSELFTEST_FRAG ]; then
+  DEFCONFIG_LIST+="$base_defconfig+$KSELFTEST_FRAG "
+fi
+
 # Tree specific fragments: stable
 if [ ${tree_name} = "stable" ] || [ ${tree_name} = "stable-rc" ]; then
   # Don't do allmodconfig builds

--- a/jenkins/kernel-trigger-tarball.sh
+++ b/jenkins/kernel-trigger-tarball.sh
@@ -135,6 +135,16 @@ fi
 
 cd ${WORKSPACE}
 
+#
+# Dynamically create some special config fragments
+#
+# kselftests: create fragment by combining all the fragments from individual selftests
+#             fragment file will have comment lines showing which selftest dir
+#             each individual fragment came from
+#
+KSELFTEST_FRAG=kernel/configs/kselftest.config
+find tools/testing/selftests -name config -printf "#\n# %h/%f\n#\n" -exec cat {} \; > $KSELFTEST_FRAG
+
 tar -czf linux-src.tar.gz --exclude=.git -C ${tree_name} .
 if [ $? != 0 ]; then
   echo "Failed to create source tarball"


### PR DESCRIPTION
There is not static kconfig fragment for kselftests. Rather, each individual kselftest comes with a config fragment for the kernel features it needs.

In order to enable a kselftest-enabled kernel build we need to

1. Dynamically create a combined kconfig fragment (patch #1)
2. Enable it as one of the defconfigs built by downstream jobs (patch #2)

Merging this pull request will enable one additional kernel build (base_defconfig + kselftest fragment) for each architecture.