### PR TITLE
wget: Do not obey the HSTS database

### DIFF
--- a/wget_retry.sh
+++ b/wget_retry.sh
@@ -5,7 +5,7 @@ SLEEPTIME=5
 COUNT=0
 while [ $COUNT -lt $RETRIES ]
 do
-    wget --progress=dot:giga --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 --tries 20 --continue "$@"
+    wget --no-hsts --progress=dot:giga --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 --tries 20 --continue "$@"
     if [ $? == 0 ]
     then
         exit 0


### PR DESCRIPTION
  * wget supports the HSTS header and stores the entries in a file
    called .wget-hsts. Force wget to not obey the header and its
    database in order to make sure it is accessing what it is told
    to.