### PR TITLE
Staging 20180626

### DIFF
--- a/build.py
+++ b/build.py
@@ -85,7 +85,7 @@ def do_post_retry(url=None, data=None, headers=None, files=None):
             if str(response.status_code)[:1] != "2":
                 raise Exception(response.content)
             else:
-                return response.content
+                return response.content, response.status_code
                 retry = False
         except Exception as e:
             print "ERROR: failed to publish"
@@ -552,7 +552,11 @@ if install:
                 count += 1
         upload_url = urljoin(api, '/upload')
         print("Uploading build to storage...")
-        publish_response = do_post_retry(url=upload_url, data=build_data, headers=headers, files=artifacts)
+        publish_response, status_code = do_post_retry(
+            url=upload_url, data=build_data, headers=headers, files=artifacts)
+        if divmod(status_code, 100)[0] != 2:
+            print("Failed to push build")
+            sys.exit(1)
         if not silent:
             print "INFO: published artifacts"
             for publish_result in json.loads(publish_response)["result"]:

--- a/build.py
+++ b/build.py
@@ -219,8 +219,7 @@ os.umask(022)
 
 # Set number of make threads to number of local processors + 2
 if os.path.exists('/proc/cpuinfo'):
-    output = subprocess.check_output('grep -c processor /proc/cpuinfo',
-                                     shell=True)
+    output = subprocess.check_output('nproc', shell=True)
     make_threads = int(output) + 2
 
 # CROSS_COMPILE

--- a/jenkins/debian/debos/overlays/networkd/etc/systemd/network/wired.network
+++ b/jenkins/debian/debos/overlays/networkd/etc/systemd/network/wired.network
@@ -1,5 +1,6 @@
 [Match]
 Name=e*
+KernelCommandLine=!nfsroot
 
 [Network]
 DHCP=yes

--- a/vars/buildImage.groovy
+++ b/vars/buildImage.groovy
@@ -17,6 +17,15 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+KCI_API_URL (https://api.kernelci.org)
+  URL of the KernelCI backend API
+KCI_TOKEN_ID
+  Identifier of the KernelCI backend API token stored in Jenkins
+
+*/
 
 
 /* TODO:
@@ -92,9 +101,9 @@ def makeImageStep(String pipeline_version, String arch, String debian_arch, Stri
                 }
 
                 stage("Upload images for ${arch}") {
-                    withCredentials([string(credentialsId: 'Staging KernelCI API Token', variable: 'API_TOKEN')]) {
+                    withCredentials([string(credentialsId: params.KCI_TOKEN_ID, variable: 'API_TOKEN')]) {
                         sh """
-                            python push-source.py --token ${API_TOKEN} --api https://staging-api.kernelci.org \
+                            python push-source.py --token ${API_TOKEN} --api ${params.KCI_API_URL} \
                                 --publish_path images/rootfs/debian/${name}/ \
                                 --file ${pipeline_version}/${arch}/*.*
                         """


### PR DESCRIPTION
Summary:

* build: use `nproc` to get the number of available CPUs and use it with `make -j`
* build: propagate any errors when sending requests to the backend API
* debos: fix NFS root by not reinitialising the network
* buildImage: user Jenkins parameters for the backend API URL and token name

Tested on staging:
https://staging.kernelci.org/build/stable/branch/linux-4.14.y/kernel/v4.14.52/

Debian rootfs builds were tested on staging as well.