### PR TITLE
staging-20180710

### DIFF
--- a/build.py
+++ b/build.py
@@ -392,7 +392,8 @@ if install:
         patterns = ['zImage', 'xipImage']
     elif arch == 'arm64':
         patterns = ['Image']
-    # TODO: Fix this assumption. ARCH != ARM* == x86
+    elif arch == 'mips':
+        patterns = ['vmlinux.bin.z', 'vmlinux.ecoff']
     else:
         patterns = ['bzImage']
 

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -181,7 +181,7 @@ def archComplete(job) {
     }
 }
 
-node("trigger") {
+node("shared-builder") {
     env.CONFIG_NUMBER = 0
     def configs = params.DEFCONFIG_LIST.tokenize(' ')
 


### PR DESCRIPTION
Leave the "trigger" node for trigger jobs, and run the build jobs on
the "shared-builder" nodes instead.

This means one executor on these nodes will be used to run the
top-level job while others will run individual kernel build stages.
The utilisation of the builders should not be impacted as long as
there are enough executors set up on them.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>