### PR TITLE
Staging 20180809

### DIFF
--- a/build.py
+++ b/build.py
@@ -449,6 +449,7 @@ if install:
         shutil.copy(os.path.join(tmp_mod_dir, modules_tarball), install_path)
         shutil.rmtree(tmp_mod_dir)
 
+    bmeta["build_threads"] = make_threads
     bmeta["build_time"] = round(build_time, 2)
     if result == 0:
         bmeta['build_result'] = "PASS"

--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ git_commit = None
 git_url = None
 git_branch = None
 ccache = None
-make_threads = 2
+make_threads = None
 kbuild_output_prefix = 'build'
 silent = True
 build_target = None
@@ -150,6 +150,9 @@ use_environment = False
 # temp frag file: used to collect all kconfig fragments
 kconfig_tmpfile_fd, kconfig_tmpfile = tempfile.mkstemp(prefix='kconfig-')
 
+# Set number of make threads to number of local processors + 2
+make_threads = int(subprocess.check_output('nproc', shell=True)) + 2
+
 # ARCH
 if os.environ.has_key('ARCH'):
     arch = os.environ['ARCH']
@@ -157,7 +160,7 @@ else:
     os.environ['ARCH'] = arch
 
 try:
-    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:sgeJ:")
+    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:sgeJ:j:")
 
 except getopt.GetoptError as err:
     print str(err) # will print something like "option -a not recognized"
@@ -213,14 +216,12 @@ for o, a in opts:
     if o == '-J':
         print("Not posting build data but saving to local JSON instead")
         build_data_json = a
+    if o == '-j':
+        make_threads = int(a)
+        print("Parallel builds: {}".format(make_threads))
 
 # Default umask for file creation
 os.umask(022)
-
-# Set number of make threads to number of local processors + 2
-if os.path.exists('/proc/cpuinfo'):
-    output = subprocess.check_output('nproc', shell=True)
-    make_threads = int(output) + 2
 
 # CROSS_COMPILE
 if cross_compilers.has_key(arch):

--- a/build.py
+++ b/build.py
@@ -157,7 +157,7 @@ else:
     os.environ['ARCH'] = arch
 
 try:
-    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:sgej:")
+    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:sgeJ:")
 
 except getopt.GetoptError as err:
     print str(err) # will print something like "option -a not recognized"
@@ -210,7 +210,7 @@ for o, a in opts:
         print "Reading build variables from environment"
         publish = True
         use_environment = True
-    if o == '-j':
+    if o == '-J':
         print("Not posting build data but saving to local JSON instead")
         build_data_json = a
 

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -52,6 +52,8 @@ KCI_BUILD_URL (https://github.com/kernelci/kernelci-build.git)
   URL of the kernelci-build repository
 KCI_BUILD_BRANCH (master)
   Name of the branch to use in the kernelci-build repository
+PARALLEL_BUILDS
+  Number of kernel builds to run in parallel
 
  */
 
@@ -63,13 +65,16 @@ import org.kernelci.util.Job
 def buildConfig(config, kdir, kci_build) {
     def defconfig = sh(script: "echo ${config} | sed 's/\\+/ \\-c /g'",
                        returnStdout: true)
-    def opt = ""
+    def opt = "-i"
 
     if (params.PUBLISH) {
-        opt = "-e"
+        opt += " -e"
     } else {
         echo "NOT PUBLISHING"
     }
+
+    if (params.PARALLEL_BUILDS)
+        opt += " -j${params.PARALLEL_BUILDS}"
 
     dir(kdir) {
         withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
@@ -77,12 +82,15 @@ def buildConfig(config, kdir, kci_build) {
             sh(script: """
 API=${params.KCI_API_URL} \
 TOKEN=${SECRET} \
-${kci_build}/build.py -i ${opt} -c ${defconfig}""")
+${kci_build}/build.py \
+  ${opt} \
+  -c ${defconfig} \
+""")
         }
     }
 }
 
-node("shared-builder") {
+node("builder") {
     echo("""\
     Tree:      ${params.TREE_NAME}
     URL:       ${params.TREE}
@@ -108,10 +116,8 @@ node("shared-builder") {
     }
 
     stage("Build") {
-        lock("${env.NODE_NAME}-build-lock") {
-            timeout(time: 60, unit: 'MINUTES') {
-                buildConfig(params.DEFCONFIG, kdir, kci_build)
-            }
+        timeout(time: 180, unit: 'MINUTES') {
+            buildConfig(params.DEFCONFIG, kdir, kci_build)
         }
     }
 }

--- a/jenkins/debian/debos/scripts/stretchtests.sh
+++ b/jenkins/debian/debos/scripts/stretchtests.sh
@@ -57,7 +57,8 @@ make V=1
 mkdir -p /tmp/tests/igt2/usr/bin
 cp -a tests/core_auth tests/core_get_client_auth tests/core_getclient tests/core_getstats tests/core_getversion \
     tests/core_prop_blob tests/core_setmaster_vs_auth tests/drm_read tests/kms_addfb_basic tests/kms_atomic \
-    tests/kms_flip_event_leak tests/kms_setmode tests/kms_vblank tests/kms_frontbuffer_tracking tests/kms_flip  /tmp/tests/igt2/usr/bin
+    tests/kms_flip_event_leak tests/kms_setmode tests/kms_vblank tests/kms_frontbuffer_tracking tests/kms_flip  \
+    tests/kms_cursor_legacy /tmp/tests/igt2/usr/bin
 strip /tmp/tests/igt2/usr/bin/*
 
 # Copy binaries in the image

--- a/jenkins/debian/debos/scripts/stretchtests.sh
+++ b/jenkins/debian/debos/scripts/stretchtests.sh
@@ -58,7 +58,7 @@ mkdir -p /tmp/tests/igt2/usr/bin
 cp -a tests/core_auth tests/core_get_client_auth tests/core_getclient tests/core_getstats tests/core_getversion \
     tests/core_prop_blob tests/core_setmaster_vs_auth tests/drm_read tests/kms_addfb_basic tests/kms_atomic \
     tests/kms_flip_event_leak tests/kms_setmode tests/kms_vblank tests/kms_frontbuffer_tracking tests/kms_flip  \
-    tests/kms_cursor_legacy /tmp/tests/igt2/usr/bin
+    tests/kms_cursor_legacy tests/testdisplay /tmp/tests/igt2/usr/bin
 strip /tmp/tests/igt2/usr/bin/*
 
 # Copy binaries in the image


### PR DESCRIPTION
Summary:
* remove build lock and add parallel build option to run multiple builds on the same node
  Note: Each builder should be adjusted to keep the number of executors and parallel builds proportional to the number of CPU cores.
* rename `-j` to `-J` option in build.py (JSON) and add `-j` for parallel builds
* add extra test utilities to Debian `stretchtests` rootfs, mostly for the `igt` test suite
* add number of build threads to the build meta-data