### PR TITLE
WIP! Start multiple-compiler work

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -171,7 +171,7 @@ def addExtraConfigs(configs, kdir, arch, tree) {
         configs.add("${base_defconfig}+${e}")
 }
 
-def buildKernelStep(job, arch, config) {
+def buildKernelStep(job, arch, config, compiler) {
     def str_params = [
         'ARCH': arch,
         'DEFCONFIG': config,
@@ -182,6 +182,7 @@ def buildKernelStep(job, arch, config) {
         'COMMIT_ID': params.COMMIT_ID,
         'BRANCH': params.BRANCH,
         'SRC_TARBALL': params.SRC_TARBALL,
+        'COMPILER': compiler,
     ]
     def job_params = []
 
@@ -238,6 +239,7 @@ node("defconfig-creator") {
     }
 
     def arch_configs = []
+    def compilers = params.COMPILERS.tokenize(' ')
 
     stage("Configs") {
         for (String arch: archs) {
@@ -256,13 +258,14 @@ node("defconfig-creator") {
     stage("Build") {
         def builds = [:]
         def i = 0
-
-        for (x in arch_configs) {
-            def arch = x[0]
-            def config = x[1]
-            echo("${i} ${arch} ${config}")
-            builds["build${i}"] = buildKernelStep("kernel-build", arch, config)
-            i += 1
+        for (compiler in compilers) {
+          for (x in arch_configs) {
+              def arch = x[0]
+              def config = x[1]
+              echo("${i} ${compiler} ${arch} ${config}")
+              builds["${i}_${compiler}_${arch}_${config}"] = buildKernelStep("kernel-build", arch, config, compiler)
+              i += 1
+          }
         }
 
         parallel(builds)

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -98,7 +98,8 @@ node("builder") {
     CPU arch:  ${params.ARCH}
     Describe:  ${params.GIT_DESCRIBE}
     Revision:  ${params.COMMIT_ID}
-    Config:    ${params.DEFCONFIG}""")
+    Config:    ${params.DEFCONFIG}
+    Compiler:  ${params.COMPILER}""")
 
     def k = new Kernel()
     def kci_build = env.WORKSPACE + '/kernelci-build'
@@ -115,9 +116,12 @@ node("builder") {
         }
     }
 
-    stage("Build") {
-        timeout(time: 180, unit: 'MINUTES') {
-            buildConfig(params.DEFCONFIG, kdir, kci_build)
+    docker.build("builder_base", "-f ${kci_build}/jenkins/dockerfiles/Dockerfile.builder_base --pull .")
+    docker.build("${params.COMPILER}_${params.ARCH}", "-f ${kci_build}/jenkins/dockerfiles/Dockerfile.${params.COMPILER}_${params.ARCH} .").inside {
+        stage("Build") {
+            timeout(time: 180, unit: 'MINUTES') {
+                buildConfig(params.DEFCONFIG, kdir, kci_build)
+            }
         }
     }
 }

--- a/jenkins/dockerfiles/Dockerfile.builder_base
+++ b/jenkins/dockerfiles/Dockerfile.builder_base
@@ -1,0 +1,7 @@
+FROM debian:buster
+MAINTAINER "Matt Hart" <matt@mattface.org>
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install bc bsdmainutils make bison flex ccache wget libelf-dev tar python2.7 python-requests python-pyelftools libssl-dev lzop
+
+#whoami doesnt work in docker
+RUN echo "#!/bin/bash\necho root\n" > /usr/bin/whoami

--- a/jenkins/dockerfiles/Dockerfile.gcc-6_arm
+++ b/jenkins/dockerfiles/Dockerfile.gcc-6_arm
@@ -1,0 +1,11 @@
+FROM builder_base:latest
+MAINTAINER "Matt Hart" <matt@mattface.org>
+
+RUN apt-get -y install gcc-6-arm-linux-gnueabihf
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-6 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-ar arm-linux-gnueabihf-ar /usr/bin/arm-linux-gnueabihf-gcc-ar-6 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-nm arm-linux-gnueabihf-nm /usr/bin/arm-linux-gnueabihf-gcc-nm-6 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-ranlib arm-linux-gnueabihf-ranlib /usr/bin/arm-linux-gnueabihf-gcc-ranlib-6 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcov arm-linux-gnueabihf-gcov /usr/bin/arm-linux-gnueabihf-gcov-6 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcov-dump arm-linux-gnueabihf-gcov-dump /usr/bin/arm-linux-gnueabihf-gcov-dump-6 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcov-tool arm-linux-gnueabihf-gcov-tool /usr/bin/arm-linux-gnueabihf-gcov-tool-6 500

--- a/jenkins/dockerfiles/Dockerfile.gcc-6_arm64
+++ b/jenkins/dockerfiles/Dockerfile.gcc-6_arm64
@@ -1,0 +1,11 @@
+FROM builder_base:latest
+MAINTAINER "Matt Hart" <matt@mattface.org>
+
+RUN apt-get -y install gcc-6-aarch64-linux-gnu
+RUN update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-6 500
+RUN update-alternatives --install /usr/bin/aarch64-linux-gnu-ar aarch64-linux-gnu-ar /usr/bin/aarch64-linux-gnu-gcc-ar-6 500
+RUN update-alternatives --install /usr/bin/aarch64-linux-gnu-nm aarch64-linux-gnu-nm /usr/bin/aarch64-linux-gnu-gcc-nm-6 500
+RUN update-alternatives --install /usr/bin/aarch64-linux-gnu-ranlib aarch64-linux-gnu-ranlib /usr/bin/aarch64-linux-gnu-gcc-ranlib-6 500
+RUN update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov aarch64-linux-gnu-gcov /usr/bin/aarch64-linux-gnu-gcov-6 500
+RUN update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-dump aarch64-linux-gnu-gcov-dump /usr/bin/aarch64-linux-gnu-gcov-dump-6 500
+RUN update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-tool aarch64-linux-gnu-gcov-tool /usr/bin/aarch64-linux-gnu-gcov-tool-6 500

--- a/jenkins/dockerfiles/Dockerfile.gcc-6_x86
+++ b/jenkins/dockerfiles/Dockerfile.gcc-6_x86
@@ -1,0 +1,5 @@
+FROM builder_base:latest
+MAINTAINER "Matt Hart" <matt@mattface.org>
+
+RUN apt-get -y install gcc-6
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 500

--- a/jenkins/dockerfiles/Dockerfile.gcc-7_arm
+++ b/jenkins/dockerfiles/Dockerfile.gcc-7_arm
@@ -1,0 +1,11 @@
+FROM builder_base:latest
+MAINTAINER "Matt Hart" <matt@mattface.org>
+
+RUN apt-get -y install gcc-7-arm-linux-gnueabihf
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-7 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-ar arm-linux-gnueabihf-ar /usr/bin/arm-linux-gnueabihf-gcc-ar-7 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-nm arm-linux-gnueabihf-nm /usr/bin/arm-linux-gnueabihf-gcc-nm-7 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-ranlib arm-linux-gnueabihf-ranlib /usr/bin/arm-linux-gnueabihf-gcc-ranlib-7 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcov arm-linux-gnueabihf-gcov /usr/bin/arm-linux-gnueabihf-gcov-7 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcov-dump arm-linux-gnueabihf-gcov-dump /usr/bin/arm-linux-gnueabihf-gcov-dump-7 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcov-tool arm-linux-gnueabihf-gcov-tool /usr/bin/arm-linux-gnueabihf-gcov-tool-7 500

--- a/jenkins/dockerfiles/Dockerfile.gcc-7_x86
+++ b/jenkins/dockerfiles/Dockerfile.gcc-7_x86
@@ -1,0 +1,5 @@
+FROM builder_base:latest
+MAINTAINER "Matt Hart" <matt@mattface.org>
+
+RUN apt-get -y install gcc-7
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 500

--- a/jenkins/dockerfiles/Dockerfile.gcc-8_arm
+++ b/jenkins/dockerfiles/Dockerfile.gcc-8_arm
@@ -1,0 +1,11 @@
+FROM builder_base:latest
+MAINTAINER "Matt Hart" <matt@mattface.org>
+
+RUN apt-get -y install gcc-8-arm-linux-gnueabihf
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-8 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-ar arm-linux-gnueabihf-ar /usr/bin/arm-linux-gnueabihf-gcc-ar-8 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-nm arm-linux-gnueabihf-nm /usr/bin/arm-linux-gnueabihf-gcc-nm-8 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-ranlib arm-linux-gnueabihf-ranlib /usr/bin/arm-linux-gnueabihf-gcc-ranlib-8 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcov arm-linux-gnueabihf-gcov /usr/bin/arm-linux-gnueabihf-gcov-8 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcov-dump arm-linux-gnueabihf-gcov-dump /usr/bin/arm-linux-gnueabihf-gcov-dump-8 500
+RUN update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcov-tool arm-linux-gnueabihf-gcov-tool /usr/bin/arm-linux-gnueabihf-gcov-tool-8 500

--- a/jenkins/dockerfiles/Dockerfile.gcc-8_x86
+++ b/jenkins/dockerfiles/Dockerfile.gcc-8_x86
@@ -1,0 +1,5 @@
+FROM builder_base:latest
+MAINTAINER "Matt Hart" <matt@mattface.org>
+
+RUN apt-get -y install gcc-8
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 500


### PR DESCRIPTION
Run builds in docker directly on the build host, and therefore be able to run multiple builds of the same job, using different compilers.

Also, as discussed on the mailing list, start using debian built toolchains for our builds.

I'm not convinced about having docker build the container on the host every time, I'd like to think we can use dockerhub to do it for us as it will only happen infrequently. For my development work I was changing the containers all the time so decided to just build them each time.

By default, we can set jenkins to just use 1 compiler, and so this can be rolled out before the backend has been taught to deal with multiple build results per defconfig.